### PR TITLE
2 create terms php

### DIFF
--- a/mesh-term.php
+++ b/mesh-term.php
@@ -1,0 +1,24 @@
+<?php namespace Mesh;
+
+class Term implements MeshObject {
+
+	function __construct( $term_name, $taxonomy ) {
+		if( is_string( $term_name ) && is_string( $taxonomy ) ) {
+			$this->maybe_create( $term_name, $taxonomy );
+		}
+	}
+
+	protected function maybe_create( $term_name, $taxonomy ) {
+		if( taxonomy_exists( $taxonomy ) && !term_exists( $term_name ) ) {
+			$this->create( $term_name, $taxonomy );
+		}
+	}
+
+	protected function create( $term_name, $taxonomy ) {
+		wp_insert_term( $term_name, $taxonomy );
+	}
+
+	public function set( $key, $value, $override = false ) {
+		// placeholder
+	}
+}

--- a/mesh.php
+++ b/mesh.php
@@ -15,6 +15,7 @@ class Mesh {
 		require_once('mesh-post.php');
 		require_once('mesh-image.php');
 		require_once('mesh-user.php');
+		require_once('mesh-term.php');
 
 		require_once('mesh-json-loader.php');
 	}


### PR DESCRIPTION
## What This Did
- Terms can now be created for a specified taxonomy with a single line of PHP, e.g 
  `$term = new Mesh\Term( 'example-term-name', 'article-type' );`
