### PR TITLE
Optional post status parameter to create method

### DIFF
--- a/lib/mesh-post.php
+++ b/lib/mesh-post.php
@@ -4,24 +4,24 @@ class Post implements MeshObject {
 
 	var $id;
 
-	function __construct( $title, $post_type = 'post' ) {
+	function __construct( $title, $post_type = 'post', $post_status = 'publish') {
 		$maybe_id = intval( $title );
 		if ( $title === $maybe_id ) {
 			$this->id = $maybe_id;
 			return;
 		}
-		$this->id = $this->maybe_create( $title, $post_type );
+		$this->id = $this->maybe_create( $title, $post_type, $post_status );
 	}
 
 	protected function get_recognized_fields() {
 		return array( 'ID', 'post_title', 'post_content', 'post_name', 'post_status', 'post_type', 'post_author', 'ping_status', 'post_parent', 'menu_order', 'to_ping', 'pinged', 'post_password', 'guid', 'post_excerpt', 'post_date', 'post_date_gmt', 'comment_status', 'post_content_filtered' );
 	}
 
-	protected function maybe_create( $title, $post_type ) {
+	protected function maybe_create( $title, $post_type, $post_status ) {
 		$slug = sanitize_title( $title );
 		$id = $this->check_if_post_exists( $slug, $post_type );
 		if ( !$id ) {
-			$id = $this->create( $title, $post_type );
+			$id = $this->create( $title, $post_type, $post_status );
 		}
 		return $id;
 
@@ -29,7 +29,7 @@ class Post implements MeshObject {
 
 	protected function create( $title, $post_type ) {
 		//insert post
-		$data = array( 'post_title' => $title, 'post_type' => $post_type, 'post_status' => 'publish' );
+		$data = array( 'post_title' => $title, 'post_type' => $post_type, 'post_status' => $post_status );
 		return wp_insert_post( $data );
 	}
 

--- a/lib/mesh-post.php
+++ b/lib/mesh-post.php
@@ -4,7 +4,7 @@ class Post implements MeshObject {
 
 	var $id;
 
-	function __construct( $title, $post_type = 'post', $post_status = 'publish') {
+	function __construct( $title, $post_type = 'post', $post_status = 'publish' ) {
 		$maybe_id = intval( $title );
 		if ( $title === $maybe_id ) {
 			$this->id = $maybe_id;


### PR DESCRIPTION
Hi @jarednova,

We use Mesh as a core component of a content importer we've written. 

Currently Mesh has `post_status` of the post hardcoded to 'publish', and this is firing off a load of actions and hooks we can't handle at that point. 

We'd like to be able to create posts and set their status to draft or pending, so I've added the post_status parameter into the Post Class `__construct`, `maybe_create` and `create` methods.

`$post_status` defaults to 'publish' so this update is backwards compatible.

Example usage:

`$mesh_post = new Mesh\Post($remote_post_object->slug, 'post', 'draft');`

Ta!

Jon
